### PR TITLE
modify format for array selecting

### DIFF
--- a/R/tidy.R
+++ b/R/tidy.R
@@ -116,7 +116,9 @@ inline.comment = ' %InLiNe_IdEnTiFiEr%[ ]*"([ ]*#[^"]*)"'
 tidy_block = function(text, width = getOption('width'), arrow = FALSE) {
   exprs = base::parse(text = text, srcfile = NULL)
   exprs = if (arrow) replace_assignment(exprs) else as.list(exprs)
-  sapply(exprs, function(e) paste(base::deparse(e, width), collapse = '\n'))
+  text = sapply(exprs, function(e) paste(base::deparse(e, width), collapse = '\n'))
+  # add one space between a left bracket and a following comma
+  text = gsub("\\[\\s*,", "\\[ ,", text)
 }
 
 #' Restore the real source code from the masked text


### PR DESCRIPTION
when selecting in an array a[,1:5,1:10]
tidy_block formats it into a[, 1:5, 1:10]
but the first comma is always easy to be neglected (not beautiful as well)
alternatively, if formatted into a[ , 1:5, 1:10]
it clearly shows that the array has 3 dimensions and what's the conditions for each.

requesting a pull to get familiar with github too..
