### PR TITLE
Reformat /test/testit/*.R

### DIFF
--- a/tests/testit/test-tidy.R
+++ b/tests/testit/test-tidy.R
@@ -4,17 +4,15 @@ tidy.res = function(x, ...) {
   tidy_source(text = x, ..., output = FALSE)$text.tidy
 }
 
-assert(
-  'tidy_source() tries to keep R comments',
-  identical(tidy.res('1+1#asdf'), '1 + 1  #asdf'),
-  identical(tidy.res('paste(1 #asdf\n,2)'), 'paste(1  #asdf\n, 2)'),
-  identical(tidy.res(c('# asdf', '1+1')), c('# asdf', '1 + 1'))
-)
+assert('tidy_source() tries to keep R comments', {
+  (identical(tidy.res('1+1#asdf'), '1 + 1  #asdf'))
+  (identical(tidy.res('paste(1 #asdf\n,2)'), 'paste(1  #asdf\n, 2)'))
+  (identical(tidy.res(c('# asdf', '1+1')), c('# asdf', '1 + 1')))
+})
 
-assert(
-  'tidy_source() preserves backslashes in comments',
-  identical(tidy.res('# \\a \\b \\c'), '# \\a \\b \\c')
-)
+assert('tidy_source() preserves backslashes in comments', {
+  (identical(tidy.res('# \\a \\b \\c'), '# \\a \\b \\c'))
+})
 
 assert('tidy_source() can preserve blank lines among non-empty code lines', {
   (tidy.res(c('if(TRUE){1+1', '', '}', '', '# a comment')) %==%
@@ -23,122 +21,108 @@ assert('tidy_source() can preserve blank lines among non-empty code lines', {
 
 x1 = paste(c('#', letters), collapse = ' ')
 x2 = c('# a b c d e f g h i j', '# k l m n o p q r s t', '# u v w x y z')
-assert(
-  'long comments are wrapped in tidy_source()',
-  identical(tidy.res(x1, width.cutoff = 20), x2),
-  identical(
+assert('long comments are wrapped in tidy_source()', {
+  (identical(tidy.res(x1, width.cutoff = 20), x2))
+  (identical(
     tidy.res(rep(x1, 2), width.cutoff = 20),
     c('# a b c d e f g h i j', '# k l m n o p q r s t', '# u v w x y z a b c d',
       '# e f g h i j k l m n', '# o p q r s t u v w x', '# y z')
-  ),
-  identical(tidy.res(c(x1, '1+1', x1), width.cutoff = 20), c(x2, '1 + 1', x2))
-)
-assert(
-  'roxygen comments are not wrapped',
-  identical(tidy.res(c(paste("#'", x1), '1*1')), c(paste("#'", x1), '1 * 1'))
-)
+  ))
+  (identical(tidy.res(c(x1, '1+1', x1), width.cutoff = 20), c(x2, '1 + 1', x2)))
+})
+
+assert('roxygen comments are not wrapped', {
+  (identical(tidy.res(c(paste("#'", x1), '1*1')), c(paste("#'", x1), '1 * 1')))
+})
 
 x1 = '
 # only a comment
 '
 x2 = c('', '# only a comment', '', '')
-assert(
-  'tidy_source() can deal with code that only contains a comment',
-  identical(tidy.res(x1), c('', '# only a comment', '')),
-  identical(tidy.res(x2), x2)
-)
+assert('tidy_source() can deal with code that only contains a comment', {
+  (identical(tidy.res(x1), c('', '# only a comment', '')))
+  (identical(tidy.res(x2), x2))
+})
 
 x1 = '{if (TRUE) {
 1
 }
 else 2}'
-assert(
-  'tidy_source() moves else back if it is in a standalone line',
-  identical(tidy.res(x1), '{\n    if (TRUE) {\n        1\n    } else 2\n}')
-)
+assert('tidy_source() moves else back if it is in a standalone line', {
+  (identical(tidy.res(x1), '{\n    if (TRUE) {\n        1\n    } else 2\n}'))
+})
 
 x1 = '{x=1
 else.x=2
 }'
 
-assert(
-  'should not move any lines starting with `else` back to the previous line',
-  tidy.res(x1) %==% '{\n    x = 1\n    else.x = 2\n}'
-)
+assert('should not move any lines starting with `else` back to the previous line', {
+  (tidy.res(x1) %==% '{\n    x = 1\n    else.x = 2\n}')
+})
 
 x1 = 'if (TRUE) {# comment
 1
 }'
-assert(
-  'comments after { are moved down one line',
-  identical(tidy.res(x1), 'if (TRUE) {\n    # comment\n    1\n}')
-)
+assert('comments after { are moved down one line', {
+  (identical(tidy.res(x1), 'if (TRUE) {\n    # comment\n    1\n}'))
+})
 
-assert(
-  'empty code returns empty string',
-  identical(tidy.res(''), ''),
-  identical(tidy.res(c('', '  ')), c('', '  '))
-)
+assert('empty code returns empty string', {
+  (identical(tidy.res(''), ''))
+  (identical(tidy.res(c('', '  ')), c('', '  ')))
+})
 
-assert(
-  'keep.comment=FALSE removes comments',
-  identical(tidy.res(c('# a comment', '1+1'), comment = FALSE), '1 + 1')
-)
+assert('keep.comment=FALSE removes comments', {
+  (identical(tidy.res(c('# a comment', '1+1'), comment = FALSE), '1 + 1'))
+})
 
-if (packageVersion('formatR') > '0.8') assert(
-  'when comment=FALSE and everything is comment, tidy_source() returns character(0)',
-  identical(tidy.res('# a comment', comment = FALSE), character(0))
-)
-
+if (packageVersion('formatR') > '0.8') {
+  assert('when comment=FALSE and everything is comment, tidy_source() returns character(0)', {
+    (identical(tidy.res('# a comment', comment = FALSE), character(0)))
+  })
+}
 x1 = '1+1
 
 if(F){
 
 }
 '
-assert(
-  'keep.blank.line=FALSE removes blank lines',
-  identical(tidy.res(x1), c('1 + 1', '', 'if (F) {\n\n}', '')),
-  identical(tidy.res(x1, blank = FALSE), c('1 + 1', 'if (F) {\n}'))
-)
+assert('keep.blank.line=FALSE removes blank lines', {
+  (identical(tidy.res(x1), c('1 + 1', '', 'if (F) {\n\n}', '')))
+  (identical(tidy.res(x1, blank = FALSE), c('1 + 1', 'if (F) {\n}')))
+})
 
-assert(
-  '= can be replaced with <- when replace.assign=TRUE',
-  identical(tidy.res('x=1;c(x=1)', arrow = TRUE), c('x <- 1', 'c(x = 1)'))
-)
+assert('= can be replaced with <- when replace.assign=TRUE', {
+  (identical(tidy.res('x=1;c(x=1)', arrow = TRUE), c('x <- 1', 'c(x = 1)')))
+})
 
-assert(
-  'since R 3.0.0 comments can be written with double quotes in them',
-  identical(tidy.res('1+1# hello "world"'), "1 + 1  # hello 'world'")
-)
+assert('since R 3.0.0 comments can be written with double quotes in them', {
+  (identical(tidy.res('1+1# hello "world"'), "1 + 1  # hello 'world'"))
+})
 
 x1 = 'x="
 # this is not a comment
 "'
-assert(
-  'since R 3.0.0, # in the beginning of a line does not necessarily mean comments',
-  identical(tidy.res(x1), 'x = "\n# this is not a comment\n"')
-)
+assert('since R 3.0.0, # in the beginning of a line does not necessarily mean comments', {
+  (identical(tidy.res(x1), 'x = "\n# this is not a comment\n"'))
+})
 
-assert(
-  'the shebang is preserved',
-  identical(tidy.res(c('#!/usr/bin/Rscript', '1+1')), c('#!/usr/bin/Rscript', '1 + 1'))
-)
+assert('the shebang is preserved', {
+  (identical(tidy.res(c('#!/usr/bin/Rscript', '1+1')), c('#!/usr/bin/Rscript', '1 + 1')))
+})
 
 x1 = paste0('x="', r <- rand_string(2000), '"')
-assert(
-  'Long strings (> 1000 chars) can be preserved',
-  tidy.res(x1) %==% paste0('x = "', r, '"')
-)
+assert('Long strings (> 1000 chars) can be preserved', {
+  (tidy.res(x1) %==% paste0('x = "', r, '"'))
+})
 
 x1 = 'x = "
   this is a
   character string
 "'
-assert(
-  'line breaks in strings are preserved instead of being replaced by \\n',
-  tidy.res(x1) %==% x1
-)
+assert('line breaks in strings are preserved instead of being replaced by \\n', {
+  (tidy.res(x1) %==% x1)
+})
 
 # tests for magrittr newlines
 

--- a/tests/testit/test-tidy.R
+++ b/tests/testit/test-tidy.R
@@ -5,13 +5,13 @@ tidy.res = function(x, ...) {
 }
 
 assert('tidy_source() tries to keep R comments', {
-  (identical(tidy.res('1+1#asdf'), '1 + 1  #asdf'))
-  (identical(tidy.res('paste(1 #asdf\n,2)'), 'paste(1  #asdf\n, 2)'))
-  (identical(tidy.res(c('# asdf', '1+1')), c('# asdf', '1 + 1')))
+  (tidy.res('1+1#asdf') %==% '1 + 1  #asdf')
+  (tidy.res('paste(1 #asdf\n,2)') %==% 'paste(1  #asdf\n, 2)')
+  (tidy.res(c('# asdf', '1+1')) %==% c('# asdf', '1 + 1'))
 })
 
 assert('tidy_source() preserves backslashes in comments', {
-  (identical(tidy.res('# \\a \\b \\c'), '# \\a \\b \\c'))
+  (tidy.res('# \\a \\b \\c') %==% '# \\a \\b \\c')
 })
 
 assert('tidy_source() can preserve blank lines among non-empty code lines', {
@@ -22,17 +22,15 @@ assert('tidy_source() can preserve blank lines among non-empty code lines', {
 x1 = paste(c('#', letters), collapse = ' ')
 x2 = c('# a b c d e f g h i j', '# k l m n o p q r s t', '# u v w x y z')
 assert('long comments are wrapped in tidy_source()', {
-  (identical(tidy.res(x1, width.cutoff = 20), x2))
-  (identical(
-    tidy.res(rep(x1, 2), width.cutoff = 20),
+  (tidy.res(x1, width.cutoff = 20) %==% x2)
+  (tidy.res(rep(x1, 2), width.cutoff = 20) %==%
     c('# a b c d e f g h i j', '# k l m n o p q r s t', '# u v w x y z a b c d',
-      '# e f g h i j k l m n', '# o p q r s t u v w x', '# y z')
-  ))
-  (identical(tidy.res(c(x1, '1+1', x1), width.cutoff = 20), c(x2, '1 + 1', x2)))
+      '# e f g h i j k l m n', '# o p q r s t u v w x', '# y z'))
+  (tidy.res(c(x1, '1+1', x1), width.cutoff = 20) %==% c(x2, '1 + 1', x2))
 })
 
 assert('roxygen comments are not wrapped', {
-  (identical(tidy.res(c(paste("#'", x1), '1*1')), c(paste("#'", x1), '1 * 1')))
+  (tidy.res(c(paste("#'", x1), '1*1')) %==% c(paste("#'", x1), '1 * 1'))
 })
 
 x1 = '
@@ -40,8 +38,8 @@ x1 = '
 '
 x2 = c('', '# only a comment', '', '')
 assert('tidy_source() can deal with code that only contains a comment', {
-  (identical(tidy.res(x1), c('', '# only a comment', '')))
-  (identical(tidy.res(x2), x2))
+  (tidy.res(x1) %==% c('', '# only a comment', ''))
+  (tidy.res(x2) %==% x2)
 })
 
 x1 = '{if (TRUE) {
@@ -49,7 +47,7 @@ x1 = '{if (TRUE) {
 }
 else 2}'
 assert('tidy_source() moves else back if it is in a standalone line', {
-  (identical(tidy.res(x1), '{\n    if (TRUE) {\n        1\n    } else 2\n}'))
+  (tidy.res(x1) %==% '{\n    if (TRUE) {\n        1\n    } else 2\n}')
 })
 
 x1 = '{x=1
@@ -64,21 +62,22 @@ x1 = 'if (TRUE) {# comment
 1
 }'
 assert('comments after { are moved down one line', {
-  (identical(tidy.res(x1), 'if (TRUE) {\n    # comment\n    1\n}'))
+  (tidy.res(x1) %==% 'if (TRUE) {\n    # comment\n    1\n}')
 })
 
 assert('empty code returns empty string', {
-  (identical(tidy.res(''), ''))
-  (identical(tidy.res(c('', '  ')), c('', '  ')))
+  (tidy.res('') %==% '')
+  (tidy.res(c('', '  ')) %==% c('', '  '))
 })
 
 assert('keep.comment=FALSE removes comments', {
-  (identical(tidy.res(c('# a comment', '1+1'), comment = FALSE), '1 + 1'))
+  (tidy.res(c('# a comment', '1+1'), comment = FALSE) %==%
+     '1 + 1')
 })
 
 if (packageVersion('formatR') > '0.8') {
   assert('when comment=FALSE and everything is comment, tidy_source() returns character(0)', {
-    (identical(tidy.res('# a comment', comment = FALSE), character(0)))
+    (tidy.res('# a comment', comment = FALSE) %==% character(0))
   })
 }
 x1 = '1+1
@@ -88,27 +87,27 @@ if(F){
 }
 '
 assert('keep.blank.line=FALSE removes blank lines', {
-  (identical(tidy.res(x1), c('1 + 1', '', 'if (F) {\n\n}', '')))
-  (identical(tidy.res(x1, blank = FALSE), c('1 + 1', 'if (F) {\n}')))
+  (tidy.res(x1) %==% c('1 + 1', '', 'if (F) {\n\n}', ''))
+  (tidy.res(x1, blank = FALSE) %==% c('1 + 1', 'if (F) {\n}'))
 })
 
 assert('= can be replaced with <- when replace.assign=TRUE', {
-  (identical(tidy.res('x=1;c(x=1)', arrow = TRUE), c('x <- 1', 'c(x = 1)')))
+  (tidy.res('x=1;c(x=1)', arrow = TRUE) %==% c('x <- 1', 'c(x = 1)'))
 })
 
 assert('since R 3.0.0 comments can be written with double quotes in them', {
-  (identical(tidy.res('1+1# hello "world"'), "1 + 1  # hello 'world'"))
+  (tidy.res('1+1# hello "world"') %==% "1 + 1  # hello 'world'")
 })
 
 x1 = 'x="
 # this is not a comment
 "'
 assert('since R 3.0.0, # in the beginning of a line does not necessarily mean comments', {
-  (identical(tidy.res(x1), 'x = "\n# this is not a comment\n"'))
+  (tidy.res(x1) %==% 'x = "\n# this is not a comment\n"')
 })
 
 assert('the shebang is preserved', {
-  (identical(tidy.res(c('#!/usr/bin/Rscript', '1+1')), c('#!/usr/bin/Rscript', '1 + 1')))
+  (tidy.res(c('#!/usr/bin/Rscript', '1+1')) %==% c('#!/usr/bin/Rscript', '1 + 1'))
 })
 
 x1 = paste0('x="', r <- rand_string(2000), '"')

--- a/tests/testit/test-tidy.R
+++ b/tests/testit/test-tidy.R
@@ -75,11 +75,10 @@ assert('keep.comment=FALSE removes comments', {
      '1 + 1')
 })
 
-if (packageVersion('formatR') > '0.8') {
-  assert('when comment=FALSE and everything is comment, tidy_source() returns character(0)', {
-    (tidy.res('# a comment', comment = FALSE) %==% character(0))
-  })
-}
+assert('when comment=FALSE and everything is comment, tidy_source() returns character(0)', {
+  (tidy.res('# a comment', comment = FALSE) %==% character(0))
+})
+
 x1 = '1+1
 
 if(F){

--- a/tests/testit/test-usage.R
+++ b/tests/testit/test-usage.R
@@ -56,8 +56,8 @@ assert('for an S3 method, usage() uses the generic function name in call signatu
     out = capture_usage(barplot.default, 60L)
     (TRUE)
   }
-  (identical(out[1L], '## Default S3 method:'))
-  (identical(substr(out[2L], 1L, 8L), 'barplot('))
+  (out[1L] %==% '## Default S3 method:')
+  (substr(out[2L], 1L, 8L) %==% 'barplot(')
 })
 
 assert('if width constraint is unfulfillable, usage() warns when fail is "warn"', {
@@ -72,7 +72,7 @@ assert('if width constraint is unfulfillable, usage() warns when fail is "warn"'
 assert('if width constraint is unfulfillable, usage() stops when fail is "stop"', {
   out = tryCatch(capture_usage(barplot.default, 30L, fail = 'stop'),
                  error = function(e) 'Error signaled')
-  (identical(out, 'Error signaled'))
+  (out %==% 'Error signaled')
 })
 
 assert('if width constraint is unfulfillable, usage() is silent when fail is "none"', {
@@ -94,7 +94,7 @@ assert('if width constraint is unfulfillable and fail is "warn" or "stop", then
           bad_lines = out[nchar(out) > 30L]
           overflow_out  = nchar(bad_lines)
           overflow_warn = as.integer(sub('^\\(([[:digit:]]*)\\).*', '\\1', warn))
-          (identical(overflow_out, overflow_warn))
+          (overflow_out %==% overflow_warn)
         })
 
 assert('usage() fits entire call on one line if it falls within width', {
@@ -102,7 +102,7 @@ assert('usage() fits entire call on one line if it falls within width', {
   width = nchar('foo(bar, ..., baz = "baz")')
   (vapply(seq(width, width + 60L, by = 5L), function(w) {
     out = usage(foo, width = w, output = FALSE)
-    identical(nchar(out), width)
+    nchar(out) %==% width
   }, logical(1)))
 })
 
@@ -115,7 +115,7 @@ assert('usage() breaks lines maximally and uniformly when all lines of same leng
     out = capture_usage(foo, width = w, indent.by.FUN = TRUE)
     (TRUE)
   }
-  (identical(length(out), 3L))
+  (length(out) %==% 3L)
   (all(nchar(out) == w))
 })
 
@@ -129,13 +129,13 @@ assert('usage() indents by getOption("formatR.indent", 4L),
            ops = options(formatR.indent = NULL)
            out = capture_usage(foo, width = 20L, indent.by.FUN = FALSE)
            options(ops)
-           (identical(out[2L], '    baz = "baz")'))
+           (out[2L] %==% '    baz = "baz")')
          }
          {
            ops = options(formatR.indent = 2L)
            out = capture_usage(foo, width = 20L)
            options(ops)
-           (identical(out[2L], '  baz = "baz")'))
+           (out[2L] %==% '  baz = "baz")')
          }
        })
 
@@ -155,7 +155,7 @@ assert('usage() breaks line on function name, if function name exceeds width', {
     reallylongfunctionname = function() {}
     w = nchar('reallylongfunctionname')
     out = capture_usage(reallylongfunctionname, w, fail = 'none')
-    (identical(out, 'reallylongfunctionname()'))
+    (out %==% 'reallylongfunctionname()')
   }
   {
     warn = tryCatch(usage(reallylongfunctionname, w, fail = 'warn'),
@@ -163,7 +163,7 @@ assert('usage() breaks line on function name, if function name exceeds width', {
                       capture.output(cat(conditionMessage(w)))
                     })
     l = nchar('reallylongfunctionname()')
-    (identical(warn[2L], sprintf('(%s) \"reallylongfunctionname()\"', l)))
+    (warn[2L] %==% sprintf('(%s) \"reallylongfunctionname()\"', l))
   }
   {
     reallylongfunctionname = function(bar, baz, ..., a, b, c, d, e) {}
@@ -180,7 +180,7 @@ assert('usage() breaks line on function name, if function name exceeds width', {
     (vapply(res, function(.) {
       all(
         nchar(.$out[-1L]) <= w,
-        identical(.$warn[2L], sprintf('(%s) \"reallylongfunctionname(\"', l))
+        .$warn[2L] %==% sprintf('(%s) \"reallylongfunctionname(\"', l)
       )
     }, logical(1)))
   }

--- a/tests/testit/test-usage.R
+++ b/tests/testit/test-usage.R
@@ -25,167 +25,146 @@ args = c(args_wo_dots, args_w_dots)
 fns = lapply(args, make_fn)
 
 # test usage() for 7.5k+ functions
-assert(
-  'usage() output respects indent and line width, whenver this is feasible',
-  {
-    ops = options(formatR.indent = 4L)
-    re = sprintf('^%s\\S', n_spaces(getOption('formatR.indent')))
-    w0 = nchar('a_function()')
-    # call with maximal set of arguments
-    usg = paste(trimws(
-      deparse(make_fn(c(args_pre, alist(... = ), args_post))),
-      which = 'left'), collapse = '')
-    w1 = nchar(sub('^function ', 'a_function', usg))
+assert('usage() output respects indent and line width, whenver this is feasible', {
+  ops = options(formatR.indent = 4L)
+  re = sprintf('^%s\\S', n_spaces(getOption('formatR.indent')))
+  w0 = nchar('a_function()')
+  # call with maximal set of arguments
+  usg = paste(trimws(
+    deparse(make_fn(c(args_pre, alist(... = ), args_post))),
+    which = 'left'), collapse = '')
+  w1 = nchar(sub('^function ', 'a_function', usg))
 
-    assertions = lapply(fns, function(f) {
-      a_function = f
-      r = (w1 - w0) %/% 4L
-      lapply(seq(w0, w1 + r, by = r), function(w) {
-        out = capture_usage(a_function, w)
-        c(
-          'output was created'        = length(out) > 0L,
-          'lines within width'        = nchar(out) <= w,
-          'indentation by indent amt' = grepl(re, out[-1L])
-        )
-      })
+  assertions = lapply(fns, function(f) {
+    a_function = f
+    r = (w1 - w0) %/% 4L
+    lapply(seq(w0, w1 + r, by = r), function(w) {
+      out = capture_usage(a_function, w)
+      c(
+        'output was created'        = length(out) > 0L,
+        'lines within width'        = nchar(out) <= w,
+        'indentation by indent amt' = grepl(re, out[-1L])
+      )
     })
-    options(ops)
-    unlist(assertions)
-  }
-)
+  })
+  options(ops)
+  (unlist(assertions))
+})
 
-assert(
-  'for an S3 method, usage() uses the generic function name in call signature',
+assert('for an S3 method, usage() uses the generic function name in call signature', {
   {
     out = capture_usage(barplot.default, 60L)
-    TRUE
-  },
-  identical(out[1L], '## Default S3 method:'),
-  identical(substr(out[2L], 1L, 8L), 'barplot(')
-)
+    (TRUE)
+  }
+  (identical(out[1L], '## Default S3 method:'))
+  (identical(substr(out[2L], 1L, 8L), 'barplot('))
+})
 
-assert(
-  'if width constraint is unfulfillable, usage() warns when fail is "warn"',
+assert('if width constraint is unfulfillable, usage() warns when fail is "warn"', {
   {
     # Verify that width constraint is unfulfillable
     out = suppressWarnings(capture_usage(barplot.default, 30L, fail = 'warn'))
     any(nchar(out) > 30L)
-  },
-  has_warning(capture_usage(barplot.default, 30L, fail = 'warn'))
-)
-
-assert(
-  'if width constraint is unfulfillable, usage() stops when fail is "stop"',
-  {
-    out = tryCatch(capture_usage(barplot.default, 30L, fail = 'stop'),
-                   error = function(e) 'Error signaled')
-    identical(out, 'Error signaled')
   }
-)
+  (has_warning(capture_usage(barplot.default, 30L, fail = 'warn')))
+})
 
-assert(
-  'if width constraint is unfulfillable, usage() is silent when fail is "none"',
-  {
-    out = tryCatch(capture_usage(barplot.default, 30L, fail = 'none'),
-                   warning = function(w) 'Warning signaled',
-                   error   = function(e) 'Error signaled')
-    !out %in% c('Warning signaled', 'Error signaled')
-  }
-)
+assert('if width constraint is unfulfillable, usage() stops when fail is "stop"', {
+  out = tryCatch(capture_usage(barplot.default, 30L, fail = 'stop'),
+                 error = function(e) 'Error signaled')
+  (identical(out, 'Error signaled'))
+})
 
-assert(
-  'if width constraint is unfulfillable and fail is "warn" or "stop", then
-   the lengths of all overflowing lines are shown',
-  {
-    out = capture.output(
-      suppressWarnings(usage(barplot.default, 30L, fail = 'warn'))
-    )
-    warn = capture.output(cat(
-      tryCatch(usage(barplot.default, 30L, fail = 'warn'),
-               warning = conditionMessage)
-    ))[-1L]
-    bad_lines = out[nchar(out) > 30L]
-    overflow_out  = nchar(bad_lines)
-    overflow_warn = as.integer(sub('^\\(([[:digit:]]*)\\).*', '\\1', warn))
-    identical(overflow_out, overflow_warn)
-  }
-)
+assert('if width constraint is unfulfillable, usage() is silent when fail is "none"', {
+  out = tryCatch(capture_usage(barplot.default, 30L, fail = 'none'),
+                 warning = function(w) 'Warning signaled',
+                 error   = function(e) 'Error signaled')
+  (!out %in% c('Warning signaled', 'Error signaled'))
+})
 
-assert(
-  'usage() fits entire call on one line if it falls within width',
-  {
-    foo = function(bar, ..., baz = "baz") {}
-    width = nchar('foo(bar, ..., baz = "baz")')
-    vapply(seq(width, width + 60L, by = 5L), function(w) {
-      out = usage(foo, width = w, output = FALSE)
-      identical(nchar(out), width)
-    }, logical(1))
-  }
-)
+assert('if width constraint is unfulfillable and fail is "warn" or "stop", then
+        the lengths of all overflowing lines are shown', {
+          out = capture.output(
+            suppressWarnings(usage(barplot.default, 30L, fail = 'warn'))
+          )
+          warn = capture.output(cat(
+            tryCatch(usage(barplot.default, 30L, fail = 'warn'),
+                     warning = conditionMessage)
+          ))[-1L]
+          bad_lines = out[nchar(out) > 30L]
+          overflow_out  = nchar(bad_lines)
+          overflow_warn = as.integer(sub('^\\(([[:digit:]]*)\\).*', '\\1', warn))
+          (identical(overflow_out, overflow_warn))
+        })
 
-assert(
-  'usage() breaks lines maximally and uniformly when all lines of same length',
+assert('usage() fits entire call on one line if it falls within width', {
+  foo = function(bar, ..., baz = "baz") {}
+  width = nchar('foo(bar, ..., baz = "baz")')
+  (vapply(seq(width, width + 60L, by = 5L), function(w) {
+    out = usage(foo, width = w, output = FALSE)
+    identical(nchar(out), width)
+  }, logical(1)))
+})
+
+assert('usage() breaks lines maximally and uniformly when all lines of same length', {
   {
     foo = function(bar, baz = 0,
                    buzz, x, ...,
                    y = 2, z = 3) {}
     w = nchar('foo(bar, baz = 0,')
     out = capture_usage(foo, width = w, indent.by.FUN = TRUE)
-    TRUE
-  },
-  identical(length(out), 3L),
-  all(nchar(out) == w)
-)
-
-assert(
-  'usage() indents by getOption("formatR.indent", 4L),
-   when indent.by.FUN is FALSE',
-  {
-    foo = function(bar, ..., baz = "baz") {}
-    TRUE
-  },
-  {
-    ops = options(formatR.indent = NULL)
-    out = capture_usage(foo, width = 20L, indent.by.FUN = FALSE)
-    options(ops)
-    identical(out[2L], '    baz = "baz")')
-  },
-  {
-    ops = options(formatR.indent = 2L)
-    out = capture_usage(foo, width = 20L)
-    options(ops)
-    identical(out[2L], '  baz = "baz")')
+    (TRUE)
   }
-)
+  (identical(length(out), 3L))
+  (all(nchar(out) == w))
+})
 
-assert(
-  'usage() indents by function name width, when indent.by.FUN is TRUE',
+assert('usage() indents by getOption("formatR.indent", 4L),
+       when indent.by.FUN is FALSE', {
+         {
+           foo = function(bar, ..., baz = "baz") {}
+           (TRUE)
+         }
+         {
+           ops = options(formatR.indent = NULL)
+           out = capture_usage(foo, width = 20L, indent.by.FUN = FALSE)
+           options(ops)
+           (identical(out[2L], '    baz = "baz")'))
+         }
+         {
+           ops = options(formatR.indent = 2L)
+           out = capture_usage(foo, width = 20L)
+           options(ops)
+           (identical(out[2L], '  baz = "baz")'))
+         }
+       })
+
+assert('usage() indents by function name width, when indent.by.FUN is TRUE', {
   {
     re = function(n) sprintf('^%s\\S', n_spaces(n))
     out1 = capture_usage(barplot.default, width = 60L, indent.by.FUN = TRUE)
     out2 = capture_usage(stats::lm, width = 60, indent.by.FUN = TRUE)
-    TRUE
-  },
-  grepl(re(nchar('barplot(')), out1[-(1L:2L)]),
-  grepl(re(nchar('lm(')), out2[-1L])
-)
+    (TRUE)
+  }
+  (grepl(re(nchar('barplot(')), out1[-(1L:2L)]))
+  (grepl(re(nchar('lm(')), out2[-1L]))
+})
 
-assert(
-  'usage() breaks line on function name, if function name exceeds width',
+assert('usage() breaks line on function name, if function name exceeds width', {
   {
     reallylongfunctionname = function() {}
     w = nchar('reallylongfunctionname')
     out = capture_usage(reallylongfunctionname, w, fail = 'none')
-    identical(out, 'reallylongfunctionname()')
-  },
+    (identical(out, 'reallylongfunctionname()'))
+  }
   {
     warn = tryCatch(usage(reallylongfunctionname, w, fail = 'warn'),
                     warning = function(w) {
                       capture.output(cat(conditionMessage(w)))
                     })
     l = nchar('reallylongfunctionname()')
-    identical(warn[2L], sprintf('(%s) \"reallylongfunctionname()\"', l))
-  },
+    (identical(warn[2L], sprintf('(%s) \"reallylongfunctionname()\"', l)))
+  }
   {
     reallylongfunctionname = function(bar, baz, ..., a, b, c, d, e) {}
     res = lapply(c(5L, 10L, 20L), function(w) {
@@ -198,14 +177,14 @@ assert(
       )
     })
     l = nchar('reallylongfunctionname(')
-    vapply(res, function(.) {
+    (vapply(res, function(.) {
       all(
         nchar(.$out[-1L]) <= w,
         identical(.$warn[2L], sprintf('(%s) \"reallylongfunctionname(\"', l))
       )
-    }, logical(1))
+    }, logical(1)))
   }
-)
+})
 
 # Test internal functions (optional) --------------------------------------
 
@@ -233,10 +212,9 @@ counts = list(
 )
 totals_manual = lapply(counts, cumsum)
 totals_count_tokens = lapply(exprs, count_tokens)
-assert(
-  'count_tokens() matches manual count of tokens',
-  unlist(
+assert('count_tokens() matches manual count of tokens', {
+  (unlist(
     Map(function(x, y) isTRUE(all.equal(x, y, check.names = FALSE)),
         totals_count_tokens, totals_manual)
-  )
-)
+  ))
+})


### PR DESCRIPTION
In assert() forms, yank description to the same line; use a single expression wrapped by {} as the second argument. Within this expression, wrap in ()s any sub-expressions which would evaluate to a logical value and be used for the assertion, including those who are returned by vapply() or Map(), as well as `TRUE`s.