### PR TITLE
Clean & reformat roxygen comments.

### DIFF
--- a/R/eval.R
+++ b/R/eval.R
@@ -1,19 +1,18 @@
-#' Evaluate R code and mask the output by a prefix
+#' Insert output to source code
 #'
-#' This function is designed to insert the output of each chunk of R code into
-#' the source code without really breaking the source code, since the output is
-#' masked in comments.
-#' @param source the input filename (by default the clipboard; see
-#'   \code{\link{tidy_source}()})
-#' @param ... other arguments passed to \code{\link{tidy_source}()}
-#' @param file the file to write by \code{\link{cat}()}; by default the output
-#'   is printed on screen
-#' @param prefix the prefix to mask the output
-#' @param envir the environment in which to evaluate the code (by default the
-#'   parent environment; if we do not want to mess up with the parent
-#'   environment, we can set \code{envir = NULL} or \code{envir = new.env()})
+#' Evaluates R code by chunks, then inserts the output to each chunk.
+#' As the output is masked in comments, the source code will not break.
+#'
+#' @param source The input file name (by default the clipboard; see
+#'   \code{\link{tidy_source}()}).
+#' @param ... Other arguments passed to \code{\link{tidy_source}()}.
+#' @param file The file name to write to via \code{\link{cat}()}.
+#' @param prefix The prefix to mask the output.
+#' @param envir The environment in which to evaluate the code. By default the
+#'   parent frame; set \code{envir = NULL} or \code{envir = new.env()} to avoid
+#'   the possibility of contaminating the parent frame.
 #' @return Evaluated R code with corresponding output (printed on screen or
-#'   written in a file).
+#'   written to a file).
 #' @export
 #' @references \url{https://yihui.org/formatR/}
 #' @examples library(formatR)
@@ -24,7 +23,7 @@
 #' tidy_eval(system.file('format', 'messy.R', package = 'formatR'))
 tidy_eval = function(source = 'clipboard', ..., file = '', prefix = '## ', envir = parent.frame()) {
   txt = tidy_source(source, ..., output = FALSE)$text.tidy
-  for(i in 1:length(txt)) {
+  for (i in 1:length(txt)) {
     cat(txt[i], '\n', sep = '', file = file, append = TRUE)
     out = capture.output(eval(res <- parse_only(txt[i]), envir = envir))
     if (length(res) > 0L && length(out) > 0L) {

--- a/R/shiny.R
+++ b/R/shiny.R
@@ -1,8 +1,8 @@
 #' A Shiny app to format R code
 #'
-#' This function calls \code{\link{tidy_source}()} to format R code in a Shiny
-#' app. The arguments of \code{tidy_source()} are presented in the app as input
-#' widgets such as checkboxes.
+#' Runs a Shiny app that formats R code via \code{\link{tidy_source}()}.
+#' This app uses input widgets, such as checkboxes, to pass arguments
+#' to \code{tidy_source()}.
 #' @export
 #' @examples if (interactive()) formatR::tidy_app()
 tidy_app = function() {

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -1,47 +1,44 @@
 #' Reformat R code while preserving blank lines and comments
 #'
-#' This function returns reformatted source code; it tries to preserve blank
-#' lines and comments, which is different with \code{\link{parse}()} and
-#' \code{\link{deparse}()}. It can also replace \code{=} with \code{<-} where
-#' \code{=} means assignments, and reindent code by a specified number of spaces
-#' (default is 4).
+#' Reads R code from a file or the clipboard and reformats it.
+#' That this function preserves blank lines and comments is a different behavior
+#' from that of \code{\link{parse}()} and \code{\link{deparse}()}.
+#' This function can also replace \code{=} with \code{<-} where \code{=} means assignment,
+#' and re-indent code with a specified number of spaces.
 #'
-#' If the value of the argument \code{width.cutoff} is wrapped in
-#' \code{\link{I}()} (e.g., \code{I(60)}), it will be treated as the \emph{upper
-#' bound} on the line width. The corresponding argument to \code{deparse()} is
-#' actually a lower bound, and so the function will perform a binary search for
+#' Value of the argument \code{width.cutoff} wrapped in
+#' \code{\link{I}()} (e.g., \code{I(60)}) will be treated as the \emph{upper
+#' bound} of the line width. The corresponding argument to \code{deparse()} is
+#' a lower bound, so the function will perform a binary search for
 #' a width value that can make \code{deparse()} return code with line width
-#' smaller than or equal to the \code{width.cutoff} value. If the search fails
-#' to find such a value, it will emit a warning, which can be suppressed by the
+#' smaller than or equal to the \code{width.cutoff} value.
+#' If the search fails, a warning will signal, suppressible by
 #' global option \code{options(formatR.width.warning = FALSE)}.
-#' @param source a character string: location of the source code (default to be
-#'   the clipboard; this means we can copy the code to clipboard and use
-#'   \code{tidy_source()} without specifying the argument \code{source})
-#' @param comment whether to keep comments (\code{TRUE} by default)
-#' @param blank whether to keep blank lines (\code{TRUE} by default)
-#' @param arrow whether to replace the assign operator \code{=} with \code{<-}
-#' @param brace.newline whether to put the left brace \code{\{} to a new line
-#'   (default \code{FALSE})
-#' @param indent number of spaces to indent the code (default 4)
-#' @param wrap whether to wrap comments to the linewidth determined by
-#'   \code{width.cutoff} (note that roxygen comments will never be wrapped)
-#' @param width.cutoff Passed to \code{\link{deparse}()}: an integer in
-#'   \code{[20, 500]} determining the cutoff at which line-breaking is tried
-#'   (default to be \code{getOption("width")}). In other words, this is the
-#'   \emph{lower bound} of the line width. See \sQuote{Details} if an upper
-#'   bound is desired instead.
-#' @param output output to the console or a file using \code{\link{cat}()}?
-#' @param text an alternative way to specify the input: if it is \code{NULL},
-#'   the function will read the source code from the \code{source} argument;
-#'   alternatively, if \code{text} is a character vector containing the source
-#'   code, it will be used as the input and the \code{source} argument will be
-#'   ignored
-#' @param ... other arguments passed to \code{\link{cat}()}, e.g. \code{file}
+#'
+#' @param source A character string: file path to the source code (defaults to
+#'   the clipboard).
+#' @param comment Whether to keep comments.
+#' @param blank Whether to keep blank lines.
+#' @param arrow Whether to replace the assign operator \code{=} with \code{<-}.
+#' @param brace.newline Whether to put the left brace \code{\{} to a new line.
+#' @param indent Number of spaces to indent the code.
+#' @param wrap Whether to wrap comments to the linewidth determined by
+#'   \code{width.cutoff} (roxygen comments will never be wrapped).
+#' @param width.cutoff An integer in \code{[20, 500]}: if a line's character length
+#' is at or over this number, the function will try to break it into a new line.
+#' In other words, this is the \emph{lower bound} of the line width.
+#' See \sQuote{Details} if an upper bound is desired instead.
+#' @param output Whether to output to the console or a file using \code{\link{cat}()}.
+#' @param text An alternative way to specify the input:
+#'   if \code{NULL}, the function will use the \code{source} argument;
+#'   if a character vector containing the source code, the function will use this
+#'   and ignore the \code{source} argument.
+#' @param ... Other arguments passed to \code{\link{cat}()}, e.g. \code{file}
 #'   (this can be useful for batch-processing R scripts, e.g.
-#'   \code{tidy_source(source = 'input.R', file = 'output.R')})
+#'   \code{tidy_source(source = 'input.R', file = 'output.R')}).
 #' @return A list with components \item{text.tidy}{the reformatted code as a
 #'   character vector} \item{text.mask}{the code containing comments, which are
-#'   masked in assignments or with the weird operator}
+#'   masked in assignments or with the weird operator}.
 #' @note Be sure to read the reference to know other limitations.
 #' @author Yihui Xie <\url{https://yihui.org}> with substantial contribution
 #'   from Yixuan Qiu <\url{https://yixuan.blog}>
@@ -208,16 +205,17 @@ unmask_source = function(text.mask, spaces) {
 
 #' Format all R scripts under a directory, or specified R scripts
 #'
-#' \code{tidy_dir()} first looks for all the R scripts under a directory (using
-#' the pattern \code{"[.][RrSsQq]$"}), then uses \code{\link{tidy_source}()} to
-#' tidy these scripts. The original scripts will be overwritten with reformatted
-#' code if reformatting was successful. You may need to back up the original
-#' directory first if you do not fully understand the tricks used by
-#' \code{\link{tidy_source}()}. \code{tidy_file()} formats specified R scripts.
-#' @param path the directory
-#' @param recursive whether to recursively look for R scripts under \code{path}
-#' @param ... other arguments to be passed to \code{\link{tidy_source}()}
-#' @param file a vector of filenames
+#' Looks for all R scripts under a directory (using the pattern \code{"[.][RrSsQq]$"}),
+#' then tidies them with \code{\link{tidy_source}()}.
+#' If successful, the original scripts will be overwritten with reformatted
+#' ones. Back up the original directory first if you do not fully understand the
+#' tricks used by \code{\link{tidy_source}()}.
+#' \code{tidy_file()} formats scripts specified by file names.
+#'
+#' @param path The path to a directory containning R scripts.
+#' @param recursive Whether to recursively look for R scripts under \code{path}.
+#' @param ... Other arguments to be passed to \code{\link{tidy_source}()}.
+#' @param file A vector of file names.
 #' @return Invisible \code{NULL}.
 #' @author Yihui Xie (\code{tidy_dir}) and Ed Lee (\code{tidy_file})
 #' @seealso \code{\link{tidy_source}()}

--- a/R/usage.R
+++ b/R/usage.R
@@ -91,22 +91,21 @@ tidy_usage = function(nm, usg, width, indent, fail) {
 
 #' Show the usage of a function
 #'
-#' Print the reformatted usage of a function. The arguments of the function are
+#' Prints the reformatted usage of a function. The arguments of the function are
 #' searched by \code{\link{argsAnywhere}()}, so the function can be either
-#' exported or non-exported in a package. S3 methods will be marked.
+#' exported or non-exported from a package. S3 methods will be marked.
 #'
-#' @param FUN the function name
-#' @param width the width of output
-#' @param tidy whether to reformat the usage code
-#' @param output whether to write the output to the console (via
-#'   \code{\link{cat}()})
-#' @param indent.by.FUN whether to indent subsequent lines by the width of the
-#'   function name (see \dQuote{Details})
-#' @param fail a character string that determines whether to generate a warning,
-#'   stop, or do neither, if the width constraint is unfulfillable (default is
-#'   \code{"warn"})
-#' @return The R code for the usage is returned as a character string
-#'   (invisibly).
+#' @param FUN The function name.
+#' @param width The width of the output.
+#' @param tidy Whether to reformat the usage code.
+#' @param output Whether to print the output to the console (via
+#'   \code{\link{cat}()}).
+#' @param indent.by.FUN Whether to indent subsequent lines by the width of the
+#'   function name (see \dQuote{Details}).
+#' @param fail A character string that represents the action taken when
+#' the width constraint is unfulfillable. "warn" and "stop" will signal
+#' warnings and errors, while "none" will do nothing.
+#' @return Reformatted usage code of a function, in character strings (invisible).
 #' @details Line breaks in the output occur between arguments. In particular,
 #'   default values of arguments will not be split across lines.
 #'


### PR DESCRIPTION
In @param fields of roxygen comments, capitalize the first letter and add period to the end.

Remove reference to default values, except where further explainations are made.

Re-write function and argument descriptions with simpler and more terse language.